### PR TITLE
fix: add AIC8800 USB DKMS for radxa-dragon-q6a

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -545,6 +545,7 @@ Architecture: all
 Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttymsm0,
+         radxa-system-config-aic8800-usb-dkms,
          ${misc:Depends},
 Recommends: task-qcs6490,
 Description: Metapackages for Dragon Q6A


### PR DESCRIPTION
https://github.com/radxa-pkg/linux-qcom/pull/4#issuecomment-3226869362