### PR TITLE
feat: Add infineon-dkms and bcmdhd-dkms for rock4 series

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -84,6 +84,7 @@ Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttyfiq0,
          radxa-system-config-r8125-dkms,
+         rkwifibt-bcmdhd-dkms,
          ${misc:Depends},
 Recommends: task-rk3399,
 Description: Metapackages for ROCK Pi 4B
@@ -96,6 +97,8 @@ Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttyfiq0,
          radxa-system-config-r8125-dkms,
+         rkwifibt-infineon-dkms,
+         rkwifibt-firmware,
          ${misc:Depends},
 Recommends: task-rk3399,
 Description: Metapackages for ROCK Pi 4C
@@ -120,6 +123,7 @@ Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttyfiq0,
          radxa-system-config-r8125-dkms,
+         rkwifibt-bcmdhd-dkms,
          ${misc:Depends},
 Recommends: task-rk3399,
 Description: Metapackages for ROCK Pi 4B+
@@ -132,6 +136,8 @@ Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttyfiq0,
          radxa-system-config-r8125-dkms,
+         rkwifibt-infineon-dkms,
+         rkwifibt-firmware,
          ${misc:Depends},
 Recommends: task-rk3399,
 Description: Metapackages for ROCK 4C+
@@ -144,6 +150,8 @@ Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttyfiq0,
          radxa-system-config-r8125-dkms,
+         rkwifibt-infineon-dkms,
+         rkwifibt-firmware,
          ${misc:Depends},
 Recommends: task-rk3399,
 Description: Metapackages for ROCK 4SE


### PR DESCRIPTION
bcmdhd-dkms for rock-pi-4b-plus and rock-pi-4b with ap6256 wifi module

infineon-dkms for rock-4se and rock-4c+ with cm256 wifi module