### PR TITLE
fix: remove 8852be-dkms dependency of CM3J

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -332,7 +332,7 @@ Architecture: all
 Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttyfiq0,
-         8852be-dkms,
+         rtw89-dkms,
          rtl8852bu-dkms,
          radxa-system-config-rtk-btusb-dkms,
          ${misc:Depends},


### PR DESCRIPTION
    fix: remove 8852be-dkms dependency of CM3J
    
    The OS of cm3j is going to be updated to Debian 12 with 6.1.84
    kernel[0]. Package 8852be-dkms failed to build with 6.1.84 kernel.
    Package 8852be-dkms is a driver for kernel < 6.1[1]. Therefore, it
    should be removed.
    
    [0]: https://github.com/radxa-pkg/linux-rk2410-nocsf/pull/18
    [1]: https://github.com/radxa-pkg/rtw89