### PR TITLE
feat: task-radxa-dragon-midstream: remove tc956x-dkms

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -556,7 +556,6 @@ Priority: optional
 Depends: radxa-system-config,
          radxa-system-config-kernel-cmdline-ttymsm0,
          radxa-system-config-aic8800-usb-dkms,
-         tc956x-dkms,
          ${misc:Depends},
 Recommends: task-qcs6490,
             task-sc8280xp,


### PR DESCRIPTION
Use the in-kernel tree tc956x driver instead.

Link: https://github.com/radxa/kernel/commit/0c14cfe24dda4f3bfdc2942c24efd62c79ab2547